### PR TITLE
Improve type stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,10 @@ TypeClasses = "addcc920-e0cf-11e8-30b7-0fb08706b574"
 Compat = "2.1, 3"
 DataTypesBasic = "1.0, 2"
 ExprParsers = "1"
-julia = "1.6"
 Monadic = "1"
 Reexport = "1"
 TypeClasses = "1.1"
+julia = "1.6"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/core.jl
+++ b/src/core.jl
@@ -12,7 +12,20 @@ only for internal purposes, captures the still unevaluated part of an Eff
 """
 struct Continuation{Fs}
   functions::Fs
-  Continuation(functions...) = new{typeof(functions)}(functions)
+  # Continuation(functions...) = new{typeof(functions)}(functions)
+  Continuation() = new{Tuple{}}(())
+  Continuation(fs::T) where {T<:Tuple} = new{T}(fs)
+  Continuation(f::F) where {F} = new{Tuple{Core.Typeof(f)}}((f,))
+end
+
+function ifemptyelse(c::Continuation{Tuple{}}, p, q)
+  @assert isempty(c)
+  p
+end
+
+function ifemptyelse(c::Continuation, p, q) 
+  @assert !isempty(c)
+  q
 end
 
 """
@@ -23,8 +36,13 @@ struct Eff{Effectful, Fs}
   effectful::Effectful
   cont::Continuation{Fs}
 
+  function Eff(effectful::T, cont::Continuation{Tuple{}}) where {T}
+      # also run this if isempty(cont) to stop infinite recursion
+      # (which happens otherwise because empty cont results returns noeffect for convenience)
+      new{T, Tuple{}}(effectful, cont)
+  end
   function Eff(effectful::T, cont::Continuation{Fs}) where {T, Fs}
-    if !isempty(cont) && effectful isa NoEffect
+    if effectful isa NoEffect
       # Evaluate NoEffect directly to make sure, we don't have a chain of NoEffect function accumulating
       # e.g. with ContextManager this could lead to things not being evaluated, while the syntax suggest
       # everything is evaluated, and hence the ContextManager may finalize resource despite they are still used.
@@ -37,6 +55,7 @@ struct Eff{Effectful, Fs}
     end
   end
 end
+
 Eff(effectful) = Eff(effectful, Continuation())
 
 function Base.show(io::IO, eff::Eff)
@@ -60,18 +79,21 @@ effect(eff::Eff) = eff  # if we find a Eff effect, we just directly use it
 # Functionalities for Continuation
 # --------------------------------
 
-function (c::Continuation)(value)
-  if isempty(c)
+function (c::Continuation{Tuple{}})(value)
     noeffect(value)
-  else
-    first_func = c.functions[1]
-    rest = c.functions[2:end]
-    eff = first_func(value)
-    Eff(eff.effectful, Continuation(eff.cont.functions..., rest...))
-  end
 end
-Base.isempty(c::Continuation) = Base.isempty(c.functions)
-Base.map(f, c::Continuation) = Continuation(c.functions..., noeffect ∘ f)
+
+function (c::Continuation)(value)
+    first_func = first(c.functions)
+    rest = Base.tail(c.functions)
+    eff = first_func(value)
+    Eff(eff.effectful, Continuation((eff.cont.functions..., rest...)))
+end
+
+Base.isempty(c::Continuation{Tuple{}}) = true
+Base.isempty(::Continuation) = false
+
+Base.map(f, c::Continuation) = Continuation((c.functions..., noeffect ∘ f))
 
 
 # Functionalities for Eff
@@ -79,4 +101,4 @@ Base.map(f, c::Continuation) = Continuation(c.functions..., noeffect ∘ f)
 
 TypeClasses.pure(::Type{<:Eff}, a) = noeffect(a)
 TypeClasses.map(f, eff::Eff) = TypeClasses.flatmap(noeffect ∘ f, eff)
-TypeClasses.flatmap(f, eff::Eff) = Eff(eff.effectful, Continuation(eff.cont.functions..., f))
+TypeClasses.flatmap(f, eff::Eff) = Eff(eff.effectful, Continuation((eff.cont.functions..., f)))

--- a/src/instances.jl
+++ b/src/instances.jl
@@ -1,4 +1,4 @@
-using ExtensibleEffects
+using .ExtensibleEffects
 using DataTypesBasic
 using TypeClasses
 using Distributed


### PR DESCRIPTION
This PR makes some adjustments that aim to improve type stability. Both JET.jl and Aqua.jl seem happier after these changes. I didn't do exhaustive performance testing, but as one proxy for this...
```julia
# Before this PR
julia> @time Pkg.test()
 17.379904 seconds (264.21 k allocations: 24.215 MiB, 0.07% gc time)

# After this PR
julia> @time Pkg.test()
 13.845315 seconds (265.68 k allocations: 24.159 MiB, 0.08% gc time)
end
```